### PR TITLE
Fix compatibility with antibot plugins

### DIFF
--- a/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
+++ b/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeListener.java
@@ -42,8 +42,12 @@ public class RedisBungeeListener implements Listener {
     private final RedisBungee plugin;
     private final List<InetAddress> exemptAddresses;
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler
     public void onLogin(final LoginEvent event) {
+        if (event.isCancelled) {
+            return;
+        }
+        
         event.registerIntent(plugin);
         plugin.getProxy().getScheduler().runAsync(plugin, new RedisCallable<Void>(plugin) {
             @Override
@@ -132,7 +136,7 @@ public class RedisBungeeListener implements Listener {
         });
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler
     public void onPing(final ProxyPingEvent event) {
         if (exemptAddresses.contains(event.getConnection().getAddress().getAddress())) {
             return;
@@ -150,6 +154,10 @@ public class RedisBungeeListener implements Listener {
     @SuppressWarnings("UnstableApiUsage")
     @EventHandler
     public void onPluginMessage(final PluginMessageEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+        
         if ((event.getTag().equals("legacy:redisbungee") || event.getTag().equals("RedisBungee")) && event.getSender() instanceof Server) {
             final String currentChannel = event.getTag();
             final byte[] data = Arrays.copyOf(event.getData(), event.getData().length);


### PR DESCRIPTION
This prevents RedisBungee from handling connections that are cancelled by antibots

(The priority change is also to prevent the cancellation ignore of antibots)