### PR TITLE
Use the correct jitpack dependency in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ then add this in your dependencies
 ```
 	<dependency>
 	    <groupId>com.github.limework.redisbungee</groupId>
-	    <artifactId>RedisBungee</artifactId>
+	    <artifactId>RedisBungee-Bungee</artifactId>
 	    <version>0.7.2</version>
 	</dependency>
 	

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ then add this in your dependencies
 	    <groupId>com.github.limework.redisbungee</groupId>
 	    <artifactId>RedisBungee-Bungee</artifactId>
 	    <version>0.7.2</version>
+	    <scope>provided</scope>
 	</dependency>
 	
 ```


### PR DESCRIPTION
The previously mentioned dependency does not exist. "RedisBungee-Bungee" with the group id "com.github.limework.redisbungee" is the correct one.