### PR TITLE
Fix NullPointerException due plugin instance for jedis tasks in UUIDTranslator/AbstractDataManager

### DIFF
--- a/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/AbstractDataManager.java
+++ b/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/AbstractDataManager.java
@@ -59,7 +59,7 @@ public abstract class AbstractDataManager<P, PL, PD, PS> {
             return plugin.isPlayerOnAServer(player) ? plugin.getPlayerServerName(player) : null;
 
         try {
-            return serverCache.get(uuid, new RedisTask<String>(plugin.getAbstractRedisBungeeApi()) {
+            return serverCache.get(uuid, new RedisTask<String>(plugin) {
                 @Override
                 public String unifiedJedisTask(UnifiedJedis unifiedJedis) {
                     return Objects.requireNonNull(unifiedJedis.hget("player:" + uuid, "server"), "user not found");
@@ -82,7 +82,7 @@ public abstract class AbstractDataManager<P, PL, PD, PS> {
             return plugin.getConfiguration().getProxyId();
 
         try {
-            return proxyCache.get(uuid, new RedisTask<String>(plugin.getAbstractRedisBungeeApi()) {
+            return proxyCache.get(uuid, new RedisTask<String>(plugin) {
                 @Override
                 public String unifiedJedisTask(UnifiedJedis unifiedJedis) {
                     return Objects.requireNonNull(unifiedJedis.hget("player:" + uuid, "proxy"), "user not found");
@@ -103,7 +103,7 @@ public abstract class AbstractDataManager<P, PL, PD, PS> {
             return plugin.getPlayerIp(player);
 
         try {
-            return ipCache.get(uuid, new RedisTask<InetAddress>(plugin.getAbstractRedisBungeeApi()) {
+            return ipCache.get(uuid, new RedisTask<InetAddress>(plugin) {
                 @Override
                 public InetAddress unifiedJedisTask(UnifiedJedis unifiedJedis) {
                     String result = unifiedJedis.hget("player:" + uuid, "ip");
@@ -127,7 +127,7 @@ public abstract class AbstractDataManager<P, PL, PD, PS> {
             return 0;
 
         try {
-            return lastOnlineCache.get(uuid, new RedisTask<Long>(plugin.getAbstractRedisBungeeApi()) {
+            return lastOnlineCache.get(uuid, new RedisTask<Long>(plugin) {
 
                 @Override
                 public Long unifiedJedisTask(UnifiedJedis unifiedJedis) {

--- a/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/UUIDTranslator.java
+++ b/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/UUIDTranslator.java
@@ -70,7 +70,7 @@ public final class UUIDTranslator {
         if (!plugin.isOnlineMode()) {
             return UUID.nameUUIDFromBytes(("OfflinePlayer:" + player).getBytes(Charsets.UTF_8));
         }
-        RedisTask<UUID> redisTask = new RedisTask<UUID>(plugin.getAbstractRedisBungeeApi()) {
+        RedisTask<UUID> redisTask = new RedisTask<UUID>(plugin) {
             @Override
             public UUID unifiedJedisTask(UnifiedJedis unifiedJedis) {
                 String stored = unifiedJedis.hget("uuid-cache", player.toLowerCase());
@@ -135,7 +135,7 @@ public final class UUIDTranslator {
                 uuidToNameMap.remove(player);
         }
 
-        RedisTask<String> redisTask = new RedisTask<String>(plugin.getAbstractRedisBungeeApi()) {
+        RedisTask<String> redisTask = new RedisTask<String>(plugin) {
             @Override
             public String unifiedJedisTask(UnifiedJedis unifiedJedis) {
                 String stored = unifiedJedis.hget("uuid-cache", player.toString());


### PR DESCRIPTION
Fixes the issue:
```
[19:09:29 ERROR]: Caused by: java.lang.NullPointerException: Cannot invoke "com.imaginarycode.minecraft.redisbungee.api.RedisBungeePlugin.isOnlineMode()" because "this.plugin" is null
[19:09:29 ERROR]:       at com.imaginarycode.minecraft.redisbungee.api.util.uuid.UUIDTranslator$2.unifiedJedisTask(UUIDTranslator.java:159)
[19:09:29 ERROR]:       at com.imaginarycode.minecraft.redisbungee.api.util.uuid.UUIDTranslator$2.unifiedJedisTask(UUIDTranslator.java:138)
[19:09:29 ERROR]:       at com.imaginarycode.minecraft.redisbungee.api.tasks.RedisTask.execute(RedisTask.java:56)
[19:09:29 ERROR]:       at com.imaginarycode.minecraft.redisbungee.api.util.uuid.UUIDTranslator.getNameFromUuid(UUIDTranslator.java:184)
[19:09:29 ERROR]:       at com.imaginarycode.minecraft.redisbungee.AbstractRedisBungeeAPI.getNameFromUuid(AbstractRedisBungeeAPI.java:316)
[19:09:29 ERROR]:       at com.imaginarycode.minecraft.redisbungee.AbstractRedisBungeeAPI.getNameFromUuid(AbstractRedisBungeeAPI.java:299)
...
```

In `UUIDTranslator` the plugin was initializing a `RedisTask` without passing the right plugin instance.
`new RedisTask<UUID>(plugin.getAbstractRedisBungeeApi())` -> `new RedisTask<UUID>(plugin)`
For this reason, the `plugin` variable inside `RedisTask` was not correctly initialized.

In some `unifiedJedisTask` methods, the variable `plugin` is used, this behavior throws a `NullPointerException`, for example in the error above:
```java
RedisTask<String> redisTask = new RedisTask<String>(plugin.getAbstractRedisBungeeApi()) {
    @Override
    public String unifiedJedisTask(UnifiedJedis unifiedJedis) {
        // ...

        if (!expensiveLookups || !plugin.isOnlineMode()) // <- Here the NullPointerException
            return null;
        // ...
    }
};
```