### PR TITLE
Use PlayerDB.co for name lookups

### DIFF
--- a/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/NameFetcher.java
+++ b/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/NameFetcher.java
@@ -29,7 +29,11 @@ public class NameFetcher {
 
     public static String getName(UUID uuid) throws IOException {
         String url = "https://playerdb.co/api/player/minecraft/" + uuid.toString();
-        Request request = new Request.Builder().url(url).get().build();
+        Request request = new Request.Builder()
+				.addHeader("User-Agent", "RedisBungee-ProxioDev")
+				.url(url)
+				.get()
+				.build();
         ResponseBody body = httpClient.newCall(request).execute().body();
         String response = body.string();
         body.close();

--- a/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/NameFetcher.java
+++ b/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/NameFetcher.java
@@ -11,50 +11,37 @@
 package com.imaginarycode.minecraft.redisbungee.api.util.uuid;
 
 import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonObject;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.ResponseBody;
+
 import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
-@Deprecated
 public class NameFetcher {
     private static OkHttpClient httpClient;
     private static final Gson gson = new Gson();
 
-    @Deprecated
     public static void setHttpClient(OkHttpClient httpClient) {
-        throw new UnsupportedOperationException("Due mojang disabled the Names API NameFetcher no longer functions and has been disabled");
-        // NameFetcher.httpClient = httpClient;
+         NameFetcher.httpClient = httpClient;
     }
 
-    @Deprecated
-    public static List<String> nameHistoryFromUuid(UUID uuid) throws IOException {
-        throw new UnsupportedOperationException("Due mojang disabled the Names API NameFetcher no longer functions and has been disabled");
-//        String url = "https://api.mojang.com/user/profiles/" + uuid.toString().replace("-", "") + "/names";
-//        Request request = new Request.Builder().url(url).get().build();
-//        ResponseBody body = httpClient.newCall(request).execute().body();
-//        String response = body.string();
-//        body.close();
-//
-//        Type listType = new TypeToken<List<Name>>() {
-//        }.getType();
-//        List<Name> names = gson.fromJson(response, listType);
-//
-//        List<String> humanNames = new ArrayList<>();
-//        for (Name name : names) {
-//            humanNames.add(name.name);
-//        }
-//        return humanNames;
-    }
+    public static String getName(UUID uuid) throws IOException {
+        String url = "https://playerdb.co/api/player/minecraft/" + uuid.toString();
+        Request request = new Request.Builder().url(url).get().build();
+        ResponseBody body = httpClient.newCall(request).execute().body();
+        String response = body.string();
+        body.close();
 
-    @Deprecated
-    public static class Name {
-        private String name;
-        private long changedToAt;
+		JsonObject json = gson.fromJson(response, JsonObject.class);
+		if (!json.has("success") || !json.get("success").getAsBoolean()) return null;
+		if (!json.has("data")) return null;
+		JsonObject data = json.getAsJsonObject("data");
+		if (!data.has("player")) return null;
+		JsonObject player = data.getAsJsonObject("player");
+		if (!player.has("username")) return null;
+
+		return player.get("username").getAsString();
     }
 }

--- a/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/NameFetcher.java
+++ b/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/NameFetcher.java
@@ -17,26 +17,34 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.ResponseBody;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 public class NameFetcher {
-    private static OkHttpClient httpClient;
-    private static final Gson gson = new Gson();
+	private static OkHttpClient httpClient;
+	private static final Gson gson = new Gson();
 
-    public static void setHttpClient(OkHttpClient httpClient) {
-         NameFetcher.httpClient = httpClient;
-    }
+	public static void setHttpClient(OkHttpClient httpClient) {
+		NameFetcher.httpClient = httpClient;
+	}
 
-    public static String getName(UUID uuid) throws IOException {
-        String url = "https://playerdb.co/api/player/minecraft/" + uuid.toString();
-        Request request = new Request.Builder()
+	public static List<String> nameHistoryFromUuid(UUID uuid) throws IOException {
+		String name = getName(uuid);
+		if (name == null) return Collections.emptyList();
+		return Collections.singletonList(name);
+	}
+
+	public static String getName(UUID uuid) throws IOException {
+		String url = "https://playerdb.co/api/player/minecraft/" + uuid.toString();
+		Request request = new Request.Builder()
 				.addHeader("User-Agent", "RedisBungee-ProxioDev")
 				.url(url)
 				.get()
 				.build();
-        ResponseBody body = httpClient.newCall(request).execute().body();
-        String response = body.string();
-        body.close();
+		ResponseBody body = httpClient.newCall(request).execute().body();
+		String response = body.string();
+		body.close();
 
 		JsonObject json = gson.fromJson(response, JsonObject.class);
 		if (!json.has("success") || !json.get("success").getAsBoolean()) return null;
@@ -47,5 +55,5 @@ public class NameFetcher {
 		if (!player.has("username")) return null;
 
 		return player.get("username").getAsString();
-    }
+	}
 }

--- a/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/UUIDTranslator.java
+++ b/RedisBungee-API/src/main/java/com/imaginarycode/minecraft/redisbungee/api/util/uuid/UUIDTranslator.java
@@ -12,7 +12,6 @@ package com.imaginarycode.minecraft.redisbungee.api.util.uuid;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import com.imaginarycode.minecraft.redisbungee.api.RedisBungeePlugin;
 
@@ -169,17 +168,12 @@ public final class UUIDTranslator {
                 if (!expensiveLookups || !plugin.isOnlineMode())
                     return null;
 
-                // That didn't work. Let's ask Mojang. This call may fail, because Mojang is insane.
-                //
-                // UPDATE: Mojang has removed the API somewhere in september/2022 due privacy issues
-                // this is expected to fail now, so we will keep logging it until we figure out something or remove name fetching completely
-                // Name fetching class was deprecated as result
+                // That didn't work. Let's ask PlayerDB.
                 String name;
                 try {
-                    plugin.logFatal("Due Mojang removing the naming API, we were unable to fetch player names.");
-                    name = Iterables.getLast(NameFetcher.nameHistoryFromUuid(player));
+                    name = NameFetcher.getName(player);
                 } catch (Exception e) {
-                    plugin.logFatal("Unable to fetch name from Mojang for " + player);
+                    plugin.logFatal("Unable to fetch name from PlayerDB for " + player);
                     return null;
                 }
 

--- a/RedisBungee-Bungee/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
+++ b/RedisBungee-Bungee/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungee.java
@@ -223,7 +223,7 @@ public class RedisBungee extends Plugin implements RedisBungeePlugin<ProxiedPlay
         httpClient = new OkHttpClient();
         Dispatcher dispatcher = new Dispatcher(getExecutorService());
         httpClient.setDispatcher(dispatcher);
-        //NameFetcher.setHttpClient(httpClient);
+        NameFetcher.setHttpClient(httpClient);
         UUIDFetcher.setHttpClient(httpClient);
         InitialUtils.checkRedisVersion(this);
         // check if this proxy is recovering from a crash and start heart the beat.

--- a/RedisBungee-Velocity/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeVelocityPlugin.java
+++ b/RedisBungee-Velocity/src/main/java/com/imaginarycode/minecraft/redisbungee/RedisBungeeVelocityPlugin.java
@@ -110,7 +110,7 @@ public class RedisBungeeVelocityPlugin implements RedisBungeePlugin<Player>, Con
         this.httpClient = new OkHttpClient();
         Dispatcher dispatcher = new Dispatcher(Executors.newFixedThreadPool(6));
         this.httpClient.setDispatcher(dispatcher);
-        //NameFetcher.setHttpClient(httpClient);
+        NameFetcher.setHttpClient(httpClient);
         UUIDFetcher.setHttpClient(httpClient);
     }
 


### PR DESCRIPTION
I noticed that currently name lookups for UUIDs that are not cached, are not supported in RedisBungee due to Mojang removing name history.

When looking at the usages, RedisBungee internally only uses the current name (So no need for full name historyy), so I moved name lookups to [PlayerDB](https://playerdb.co/), which does not have API rate limits unlike Mojang's API.

Due to removing the `NameFetcher#nameHistoryFromUuid`, this might break backwards compatibility, but it should be easy to re-add the method and throw an exception like it does now.

closes #59 